### PR TITLE
Fix empty bars in overview stake/weights charts

### DIFF
--- a/src/utils/overview/overview.ts
+++ b/src/utils/overview/overview.ts
@@ -1,7 +1,6 @@
 import { PosOverviewData, PosOverviewSlice } from 'pos-analytics-graph';
 import { TFunction } from 'i18next';
 import moment from 'moment';
-import _ from 'lodash';
 import { ChartUnit, OverviewSections } from '../../global/enums';
 import { GuardiansChartDatasetObject, MenuOption, OverviewGuardianDataset } from '../../global/types';
 import { routes } from '../../routes/routes';
@@ -79,40 +78,28 @@ export const getMinDateByUnitOverview = (unit: ChartUnit): Date => {
     }
 };
 
-export const groupDataset = (slices: PosOverviewSlice[], unit: ChartUnit) => {
-    const limit = getMinDateByUnitOverview(unit);
-    const limitMilliseconds = moment(limit).valueOf();
-    const filtered = slices.filter((slice) => {
-        const { block_time } = slice;
-        const blockTimeMilliseconds = moment.unix(block_time).valueOf();
-        return blockTimeMilliseconds > limitMilliseconds;
-    });
-    const mapped = filtered.map((slice) => {
-        let prev: PosOverviewData[] = [];
-        const { block_time, data } = slice;
-        const date = moment.unix(block_time).format(DATE_FORMAT);
-        const { length } = data;
-        if (length > 0) {
-            prev = data;
+// Committee stake/weight is a step function: a chart bucket must show the state
+// carried forward from the most recent committee event at or before it - NOT only
+// events that happened to land on the bucket's exact calendar day (the old behavior,
+// which left random bars empty depending on which weekday the site was opened).
+export const forEachBucketSlice = (
+    slices: PosOverviewSlice[],
+    guardianDatasets: { [id: string]: OverviewGuardianDataset },
+    fill: (slice: PosOverviewSlice, bucketX: string, index: number) => void
+) => {
+    const sample = Object.values(guardianDatasets)[0];
+    if (!sample || !Array.isArray(sample.data)) return;
+    const sorted = [...slices].sort((s1, s2) => s1.block_time - s2.block_time);
+    sample.data.forEach((point: GuardiansChartDatasetObject, index: number) => {
+        const bucketEnd = moment(point.x as string, DATE_FORMAT)
+            .endOf('day')
+            .unix();
+        let latest: PosOverviewSlice | null = null;
+        for (const slice of sorted) {
+            if (slice.block_time > bucketEnd) break;
+            latest = slice;
         }
-        return {
-            ...slice,
-            date,
-            data: length > 0 ? data : prev
-        };
+        if (!latest) return; // bucket predates all known data
+        fill(latest, point.x as string, index);
     });
-    const result = createGroupedDataset(mapped);
-    return result;
-};
-
-const createGroupedDataset = (mapped: any) => {
-    const grouped = _(mapped)
-        .groupBy((x) => x.date)
-        .map((value, key) => {
-            const sorted = value.sort((s1: PosOverviewSlice, s2: PosOverviewSlice) => s1.block_time - s2.block_time);
-            const slice = sorted[sorted.length - 1];
-            return { date: key, slice };
-        })
-        .value();
-    return grouped;
 };

--- a/src/utils/overview/stake-chart.ts
+++ b/src/utils/overview/stake-chart.ts
@@ -3,8 +3,7 @@ import { GuardiansChartDatasetObject, OverviewGuardianDataset } from 'global/typ
 import { ChartUnit } from '../../global/enums';
 import {  OVERVIEW_CHART_LIMIT } from '../../global/variables';
 import {  generateDays, generateWeeks } from '../dates';
-import { createGuardianDatasets, getLastSlice, groupDataset } from './overview';
-import { findIndexInArray } from 'utils/array';
+import { createGuardianDatasets, forEachBucketSlice, getLastSlice } from './overview';
 import _ from 'lodash';
 export const generateDataset = (arr: any) => {
     const result = Object.keys(arr).map((key) => {
@@ -20,19 +19,14 @@ const insertGuardiansByDate = (
     guardianDatasets: { [id: string]: OverviewGuardianDataset }
 ) => {
     const totalObject: any = {};
-    const grouped = groupDataset(slices, unit);
-    grouped.forEach(({ slice, date }: any) => {
-    
-        const { data, total_effective_stake } = slice;
-        totalObject[date] = total_effective_stake;
-        data.forEach(({ effective_stake, address }: PosOverviewData) => {
+    forEachBucketSlice(slices, guardianDatasets, (slice, bucketX, index) => {
+        totalObject[bucketX] = slice.total_effective_stake;
+        slice.data.forEach(({ effective_stake, address }: PosOverviewData) => {
             const currDataset = guardianDatasets[address];
             if (!currDataset) return;
-            const index = findIndexInArray(currDataset.data as any, 'x', date);
-            if (index < 0) return;
             const point: GuardiansChartDatasetObject = {
-                group: date,
-                x: date,
+                group: bucketX,
+                x: bucketX,
                 y: effective_stake
             };
             currDataset.data.splice(index, 1, point);

--- a/src/utils/overview/weights-chart.ts
+++ b/src/utils/overview/weights-chart.ts
@@ -1,10 +1,9 @@
 import { PosOverview, PosOverviewSlice, PosOverviewData } from 'pos-analytics-graph';
 import { OverviewGuardianDataset, GuardiansChartDatasetObject } from 'global/types';
-import { findIndexInArray } from 'utils/array';
 import { ChartUnit } from '../../global/enums';
 import { OVERVIEW_CHART_LIMIT } from '../../global/variables';
 import { generateWeeks, generateDays } from '../dates';
-import { createGuardianDatasets, getLastSlice, groupDataset } from './overview';
+import { createGuardianDatasets, forEachBucketSlice, getLastSlice } from './overview';
 
 export const generateDataset = (arr: any) => {
     const result = Object.keys(arr).map((key) => {
@@ -27,27 +26,19 @@ const insertGuardiansByDate = (
     unit: ChartUnit,
     guardianDatasets: { [id: string]: OverviewGuardianDataset }
 ) => {
-    const grouped = groupDataset(slices, unit);
     const totalObject: any = {};
-    grouped.forEach(({ slice, date }: any) => {
-        const { data, total_weight, total_effective_stake } = slice;
-        totalObject[date] = total_effective_stake;
-        const total = calcTotalWeight(data)
-        data.forEach(({ weight, address }: PosOverviewData) => {
-          
+    forEachBucketSlice(slices, guardianDatasets, (slice, bucketX, index) => {
+        totalObject[bucketX] = slice.total_effective_stake;
+        const total = calcTotalWeight(slice.data);
+        slice.data.forEach(({ weight, address }: PosOverviewData) => {
             const currDataset = guardianDatasets[address];
             if (!currDataset) return;
-            const index = findIndexInArray(currDataset.data as any, 'x', date);
-            if (index < 0) {
-                return;
-            }
             const percent = (weight / total) * 100;
             const point: GuardiansChartDatasetObject = {
-                group: date,
-                x: date,
+                group: bucketX,
+                x: bucketX,
                 y: percent
             };
-
             currDataset.data.splice(index, 1, point);
         });
     });


### PR DESCRIPTION
The Weeks/Days overview charts sampled one exact calendar day per bucket (anchored to today's weekday) instead of carrying the committee state forward, so any bucket whose anchor day had no committee event rendered empty - including, always, the current week before its first event. Both bars in the report screenshot (23 Jun, 21 Jul) are explained by this; the node data has full committees every week.

Fix: each bucket now shows the latest committee state at or before its day (step-function semantics), via a shared `forEachBucketSlice` helper used by the stake and weights charts. Verified in-browser: all buckets filled, values match adjacent event data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)