### PR TITLE
Fix guardian selector dropdown layering

### DIFF
--- a/src/screens/guardians/components/guardian-top/guardian-top.scss
+++ b/src/screens/guardians/components/guardian-top/guardian-top.scss
@@ -4,6 +4,9 @@
   box-shadow: 0px 5px 10px #0812261a;
   padding: 30px 20px 20px 20px;
   border-radius: 10px;
+  overflow: visible;
+  position: relative;
+  z-index: 20;
 
   .component-wrapper {
     flex-wrap: wrap;
@@ -42,7 +45,7 @@
 
 @media (max-width: 767px) {
   .app--mobile .guardian-top {
-    overflow: hidden;
+    overflow: visible;
     height: auto;
     padding: 20px;
     box-shadow: none;


### PR DESCRIPTION
## Summary
- raise the Guardian header into its own stacking layer
- allow the selector dropdown to overflow above the detail section
- remove mobile overflow clipping

## Validation
- 17 test files / 48 tests passed
- TypeScript typecheck passed
- Vite production build passed
- desktop and tablet browser hit-testing and final-row selection passed